### PR TITLE
Automate OP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ vagrant plugin install vagrant-parallels
 
 git clone git@github.com:eanders/vagrant-op.git op
 ```
-Either clone or copy in your existing [HMIS Warehouse](http://github.com/greenriver/hmis-warehouse) and [CAS](http://github.com/greenriver/boston-cas) directories into the `op` folder created above.
+Either copy in your existing [HMIS Warehouse](http://github.com/greenriver/hmis-warehouse) and [CAS](http://github.com/greenriver/boston-cas) directories into the `op` folder created above, or they will be cloned and a default configuration will be created.
 
 Initialize with a VirtualBox provider
 ```bash
@@ -26,7 +26,9 @@ Future starts can be run as
 vagrant up
 ```
 
-To access the web interface outside of the vagrant container, you'll need to add certificates for nginx-proxy [as noted in the warehouse networking setup](https://github.com/greenriver/hmis-warehouse/blob/production/docs/developer-networking.md#certificate) and then restart vagrant.
+To access the web interface outside of the vagrant container, you'll need to add certificates for nginx-proxy [as noted in the warehouse networking setup](https://github.com/greenriver/hmis-warehouse/blob/production/docs/developer-networking.md#certificate) and then restart vagrant. If you allowed vagrant to clone
+and create a default configuration, the certificates will be created for you,
+but you will still need to install them on your local machine.
 
 
 If you want both CAS and the warehouse to share a database server, you may want to add a `docker-compose.override.yml` to one of the warehouse installation that puts the db container on a different port. 
@@ -53,3 +55,5 @@ services:
     ports:
       - 6378 # hide redis from the warehouse
 ```
+
+This is the default if you allowed vagrant to create a configuration.

--- a/bootstrap_user.sh
+++ b/bootstrap_user.sh
@@ -5,6 +5,24 @@ echo "export GPG_TTY=$(tty)" >> /home/vagrant/.bashrc
 echo "alias dcr='docker-compose run --rm'" >> /home/vagrant/.bashrc
 # add keys so we don't need to enter the password always
 echo "ssh-add" >> /home/vagrant/.bashrc
+
+if [ ! -d /vagrant/boston-cas ]; then
+  git clone git@github.com:greenriver/boston-cas.git /vagrant/boston-cas
+  cp /vagrant/cas-docker-compose.override.yml /vagrant/boston-cas/docker-compose.override.yml
+  cp /vagrant/boston-cas/.env.sample /vagrant/boston-cas/.env.local
+  echo "RAILS_ENV=test" > /vagrant/boston-cas/.env.test
+fi
+
+if [ ! -d /vagrant/hmis-warehouse ]; then
+  git clone git@github.com:greenriver/hmis-warehouse.git /vagrant/hmis-warehouse
+  cp /vagrant/hmis-docker-compose.override.yml /vagrant/hmis-warehouse/docker-compose.override.yml
+  cp /vagrant/hmis-warehouse/sample.env /vagrant/hmis-warehouse/.env.local
+  openssl req -new -newkey rsa:2048 -sha256 -days 3650 -nodes -x509 \
+    -keyout /vagrant/hmis-warehouse/docker/nginx-proxy/certs/dev.test.key \
+    -out /vagrant/hmis-warehouse/docker/nginx-proxy/certs/dev.test.crt \
+    -config /vagrant/openssl.cnf
+fi
+
 ln -s /vagrant/boston-cas ~/boston-cas
 ln -s /vagrant/hmis-warehouse ~/hmis-warehouse
 

--- a/cas-docker-compose.override.yml
+++ b/cas-docker-compose.override.yml
@@ -1,0 +1,8 @@
+services:
+  db:
+    ports:
+      - 5433:5433
+    command: ['postgres', '-c', 'max_connections=500', '-c', 'log_statement=all', '-c', 'port=5433']
+  redis:
+    ports:
+      - 6378 # hide redis from the warehouse

--- a/hmis-docker-compose.override.yml
+++ b/hmis-docker-compose.override.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  db:
+   ports:
+     - 5432:5432
+   command: ['postgres', '-c', 'max_connections=500', '-c', 'log_statement=all', '-c', 'port=5432']
+

--- a/openssl.cnf
+++ b/openssl.cnf
@@ -1,0 +1,15 @@
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+CN = *.dev.test
+
+[v3_req]
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = *.dev.test
+DNS.2 = dev.test


### PR DESCRIPTION
This will automatically clone and configure the warehouse and CAS in vagrant. It did surface some issues in the underlying repositories to be fixed:

- CAS won't run without manually creating `theme/styles/_variables.css`
- There are quoting problems with the email addresses in the sample `.env`s for both CAS and the warehouse.

This does not run `db_prep` -- maybe it should?